### PR TITLE
更改杀掉 Mojo-QQ 所使用的 signal

### DIFF
--- a/node/index.js
+++ b/node/index.js
@@ -21,12 +21,13 @@ var debug = config.debug || false;
 
 console.dir(ffmConfig.ids);
 
-process.on('exit', function () {
+function exitHandler () {
     // TODO push to client server exited
     console.log("[FFM] exit");
     mojoQQ.kill('SIGTERM');
-});
-
+}
+process.on('exit', exitHandler);
+process.on('SIGINT', exitHandler);
 
 var proxy = httpProxy.createProxyServer({
     proxyTimeout: 3000

--- a/node/index.js
+++ b/node/index.js
@@ -24,7 +24,7 @@ console.dir(ffmConfig.ids);
 process.on('exit', function () {
     // TODO push to client server exited
     console.log("[FFM] exit");
-    mojoQQ.kill('SIGINT');
+    mojoQQ.kill('SIGTERM');
 });
 
 
@@ -98,7 +98,7 @@ function handle(req, res) {
         case '/ffm/stop':
             res.writeHead(200, {"Content-Type": "application/json"});
             res.end(JSON.stringify({
-                code: mojoQQ.kill('SIGINT') ? 1 :0
+                code: mojoQQ.kill('SIGTERM') ? 1 :0
             }));
             break;
         case '/ffm/get_qr_code':


### PR DESCRIPTION
INT信号会被Mojo直接忽略掉，因此每次重启 FFM server 都要手动kill原先的pid，客户端使用API也无法停止服务端。

ref: https://github.com/sjdy521/Mojo-Webqq/blob/6abc68c4317921916c6e6800d5e1eb293e61bca5/lib/Mojo/Webqq.pm#L266